### PR TITLE
Update AM-CDM-base.sadl

### DIFF
--- a/SADL/AM-CDM-base.sadl
+++ b/SADL/AM-CDM-base.sadl
@@ -57,7 +57,7 @@ Country (note "A country.") is a class,
 	described by countryName (note "The country's name.") with a single value of type string,
 	described by countryAlpha2Code (note "Two-digit country code.") with a single value of type string,
 	described by countryAlpha3Code (note "Three-digit country code.") with a single value of type string,
-	described by countryCallingCode (note "The calling code for the country.") with a single value of type int.
+	described by countryCallingCode (note "The calling code for the country.") with a single value of type string.
 
 Coordinate (note "A coordinate to position an object in reference to something.") is a class.
 


### PR DESCRIPTION
Changed countryCallingCode range to string. It previously had as its range xsd:int, which should be reserved for things that people can do math with, like counting product, measuring weight, etc.  Phone number as a data property already has xsd:int in the range.