### PR TITLE
fast refactor of system

### DIFF
--- a/SADL/AM-CDM-part.sadl
+++ b/SADL/AM-CDM-part.sadl
@@ -10,7 +10,6 @@ Part (note "Instances of part designs in the as-built state.") is a MaterialStoc
 	described by partProcessSpecificPartDesign (note "A design file which specifies the part at the completion of a manufacturing process step. This is not the specification for completed part.") with values of type PartSpecificProcessParameters,
 	described by partProject (note "The project that this part is associated with") with values of type Project.
 
-
 DesignSpecification (note "Specification for a part.") is a class,
     described by designSpecName (note 'Human readable name which designates this design specification.') with a single value of type string,
 	described by designSpecAuthor (note "Author of design specification.") with a single value of type Person,

--- a/SADL/AM-CDM-system.sadl
+++ b/SADL/AM-CDM-system.sadl
@@ -2,163 +2,127 @@ uri "http://kdl.ge.com/AM-CDM-system" alias AM-CDM-system version "$Revision:$ L
 
 import "http://kdl.ge.com/AM-CDM-material".
 
-System (note "System information.") is a class,
+System (note "A manufacturing system that may be an aggregate of subsystems.") is a class,
 	described by systemID (note "Unique identifier of equipment.") with a single value of type string,
 	described by systemName (note "The name of the equipment.") with a single value of type string,
-	described by systemModel (note "Model name of a machine defined by the machine manufacturer.") with a single value of type string,
-	described by systemManufacturer (note "The manufacturer of the equipment.") with a single value of type Organization,
-	described by systemSerialNumber (note "The serial number of the equipment defined by the vendor.") with a single value of type string,
 	described by systemPurchaseDate (note "The purchase/certification date of the installed equipment.") with a single value of type dateTime,
 	described by systemOwner (note "The owner/organization of the equipment.") with a single value of type Organization,
 	described by systemLocation (note "The location where the equipment is installed.") with a single value of type Address,
-	described by systemCalibration (note "Calibration information. A calibration event triggers a revision to the system.") with a single value of type SystemCalibration,
-	described by systemMaintenanceEvent (note "Maintenance events performed on system.") with values of type MaintenanceEvent,
+	described by systemSpecification with a single value of type SystemSpecification,
+	described by systemProcessHistory with a single value of type ProcessHistory,
+	described by systemComponents with values of type System.
+	described by amSystemMachineCapability (note "Vendor provided AM machine specification.") with a single value of type MachineCapability,
+
+SystemSpecification is a class,
+	described by systemModel (note "Model name of a machine defined by the machine manufacturer.") with a single value of type string,
+	described by systemManufacturer (note "The manufacturer of the equipment.") with a single value of type Organization,
+	described by systemSerialNumber (note "The serial number of the equipment defined by the vendor.") with a single value of type string,
+	described by systemSpecElectricVoltage (note "Voltage for an AM Machine's electrical connection.") with a single value of type Measurement,
+	described by systemSpecPowerIntensity (note "Current intensity required to power an AM Machine.") with a single value of type Measurement,
+	described by systemSpecPowerFrequency (note "Power frequency for the electrical connection of an AM Machine.") with a single value of type Measurement,
 	described by systemSoftware (note "Computer programs required for operation of this system.") with values of type Software.
 
-SystemCalibration (note "Calibration information.") is a type of MaintenanceEvent,
-	described by calibrationID (note "ID of a calibration process.") with a single value of type string,
-	described by calibrationDate (note "Date of machine calibration.") with a single value of type dateTime,
-	described by calibrationOperator (note "Person performing the machine calibration. Links to Personnel ID.") with a single value of type Person,
-	described by calibrationPassFail (note "Pass / fail result.") with a single value of type string,
-	described by calibrationResults (note "The results of the equipment calibration (files, etc.).") with a single value of type Document,
-	described by calibrationMachineCalibrationNotes (note "Comments of a machine calibration.") with a single value of type string,
-	described by calibrationMachineCalibrationReport (note "Technical report from the calibration.") with a single value of type Document.
+AMSystem is a System,
+	described by systemSpecification with a single value of type AMSystemSpecification,
 
-AMSystem (note "Additive Manufacturing System Machine and auxiliary equipment used for additive manufacturing.") is a type of System,
-	described by amSystemMachineAcceptanceDate (note "Date when an AM machine is certified as Installation Qualified (passes the site acceptance test, or Installation qualification).") with a single value of type dateTime,
-	described by amSystemSystemProcessType (note "Process category of an AM system defined by ASTM 52900 process categories.") with a single value of type string, // enumerated list based on AMSystem Types (see below)
-	described by amSystemSystemSubprocessType (note "Sub Process category of an AM system.") with a single value of type string,
-	described by amSystemMachineElectricVoltage (note "Voltage for an AM Machine's electrical connection.") with a single value of type Measurement,
-	described by amSystemMachinePowerIntensity (note "Current intensity required to power an AM Machine.") with a single value of type Measurement,
-	described by amSystemMachinePowerFrequency (note "Power frequency for the electrical connection of an AM Machine.") with a single value of type Measurement,
-	described by amSystemSystemInstallationQualification (note "A certification capturing the basic calibration and test build(s) performed after installation of machine; aka, suite acceptance report, tied to a machine serial number.") with a single value of type string,
-	described by amSystemSystemOperationQualification (note "A certification capturing process control, maintenance, calibration to ensure a stable process that meets the requirements of a material specification; tied to a machine serial number.") with a single value of type string,
-	described by amSystemSystemFacility (note "Name of the facility where an AM system is installed.") with a single value of type Organization,
-	described by amSystemMachineHazmatRequirements (note "A document of a link to AM Machine HAZMAT Requirements.") with a single value of type string,
-	described by amSystemMachineCapability (note "Vendor provided AM machine specification.") with a single value of type MachineCapability,
-	described by amSystemInSituMonitoringSystem with values of type InSituMonitoringSystem,
-//	described by amSystemSpecificSubsystem with values of type SpecificSubsystem.
-	described by amSystemComponentSystem with values of type System.
+AMSystemSpecification is a type of SystemSpecification,
+	described by amSystemMachineHazmatRequirements (note "A document of a link to AM Machine HAZMAT Requirements.") with a single value of type string.
 
-InSituMonitoringSystem (note "The technology, including both hardware and software, used to observe and record the progress of an additive manufacturing process as it occurs in real time. Each individual piece of monitoring technology constitutes a separate in-situ monitoring system. An in-situ monitoring system may be built into an AM System by the AM System Manufacturer, or a third-party monitoring system may be attached by the owning organization.") is a type of System,
-	described by inSituSystemTechnology (note "The technology, including both hardware and software, used to observe and record the progress of an additive manufacturing process.") with a single value of type string,
-	described by inSituSystemSensingType (note "The type of an in-situ monitoring sensing technique.") with a single value of type string,
-	described by inSituSystemSamplingRate (note "Default sampling rate: Hz for time series data; fps for evenly sampled imaging system; images/layers for layerwise imaging system.") with a single value of type Measurement,
-//	described by specificSubsystem with values of type SpecificSubsystem.
-	described by inSituSystemComponentSystem with values of type System.
+Sensor is a System,
+	described by systemSpecification with a single value of type SensorSpecification.
 
-//SpecificSubsystem (note "Describes equipment that can be interchanged from AMSystem or InSituMonitoringSystem that would be in use for a build.") is a type of System.
+SensorSpecification is a type of SystemSpecification,
+	described by samplingRateMin with a single value of type Measurement,
+	described by samplingRateMax with a single value of type Measurement.
 
-//Build Specific Subsystems
-//BuildChamber (note "Enclosed location within the additive manufacturing system where the parts are fabricated.") is a type of SpecificSubsystem,
 BuildChamber (note "Enclosed location within the additive manufacturing system where the parts are fabricated.") is a type of System,
 	described by buildChamberEnvironmentalControl (note "Environment control of the build chamber on its temperature, pressure, humidity and oxygen level, for optimal quality of AM material transformation.") with a single value of type BuildEnvironmentalControl,
 	described by buildChamberVolume (note "total usable volume available in the machine for building parts.") with a single value of type BuildVolume.
 
-//LaserSystem is a type of SpecificSubsystem,
-LaserSystem is a type of System,
+LaserSystem is a System,
+	described by systemSpecification with a single value of type LaserSystemSpecification,
+	// BeamProfile should be the output of a maintenance event
+	described by laserSystemLaserBeamProfile with a single value of type Document.
+
+LaserSystemSpecification is a type of SystemSpecification,
 	described by laserSystemNumberOfLasers with a single value of type int,
 	described by laserSystemModeOfLaserOperation with a single value of type string,
-	described by laserSystemLaserType with a single value of type string,
 	described by laserSystemMaxLaserPower with a single value of type Measurement,
 	described by laserSystemMinLaserPower with a single value of type Measurement,
 	described by laserSystemRatedWaveLength with a single value of type Measurement,
 	described by laserSystemBeamShape with a single value of type string,
-	described by laserSystemBeamDiameter with a single value of type Measurement,
-	described by laserSystemLaserBeamSpotSizeType with a single value of type string,
 	described by laserSystemMaxBeamSpotSize with a single value of type Measurement,
 	described by laserSystemMinBeamSpotSize with a single value of type Measurement,
 	described by laserSystemFocusCorrectionType with a single value of type string,
-	described by laserSystemLaserManufacturer with a single value of type Organization,
-	described by laserSystemLaserModelName with a single value of type string,
-	described by laserSystemLaserSystemSerialNumber with a single value of type string,
-	described by laserSystemPrecisionLensMaterialType with a single value of type MaterialType,
-	described by laserSystemLaserBeamProfile with a single value of type Document.
 
-//RecoatingSystem is a type of SpecificSubsystem,
-RecoatingSystem is a type of System,
-	described by recoatingSystemType with a single value of type string,
+Recoater is a System,
+	described by systemSpecification with a single value of type RecoaterSpecification.
+
+RecoaterSpecification is a type of SystemSpecification,
+	described by samplingRateMin with a single value of type Measurement,
+	described by samplingRateMax with a single value of type Measurement.
 	described by recoaterMaximumSpeed with a single value of type Measurement,
 	described by recoaterMaxUsesAllowed with a single value of type integer,
-	described by bladeID with a single value of type string,
 	described by recoatingBladeMaterialType with a single value of type MaterialType,
-	described by recoatingBladePartNumber with a single value of type string,
-	described by recoatingBladeMaterialSpecification with a single value of type Document,
-	described by recoatingBladeDrawing with a single value of type Document,
-	described by recoatingRakeAngle with a single value of type Measurement,
-	described by recoatingClearanceAngle with a single value of type Measurement,
-	described by recoatingMechanismType with a single value of type string,
-	described by recoatingRollerID with a single value of type string,
-	described by recoatingRollerMaterialType with a single value of type MaterialType,
-	described by recoatingRollerDiameter with a single value of type Measurement,
-	described by recoatingMaxRollingAngularSpeed with a single value of type Measurement,
-	described by recoatingRollerSpinDirection with a single value of type string,
-	described by recoatingDateOfLastRollerCleaning with a single value of type dateTime.
+	described by recoatingBladeMaterialSpecification with a single value of type Document.
 
-//GalvoScanner is a type of SpecificSubsystem,
-GalvoScanner is a type of System,
-	described by galvoScannerManufacturer with a single value of type string,
-	described by galvoScannerModel with a single value of type string,
+GalvoScanner is a System,
+	described by systemSpecification with a single value of type GalvoScannerSpecification.
+
+GalvoScannerSpecification is a type of SystemSpecification,
 	described by galvoScannerMaxScanAngleX with a single value of type Measurement,
 	described by galvoScannerMaxScanAngleY with a single value of type Measurement,
 	described by galvoScannerRepeatability with a single value of type Measurement,
 	described by galvoScannerMaxScanSpeed with a single value of type Measurement,
-	described by galvoScannerCalibrationDate with a single value of type dateTime,
+	// Key question for data registration: How do we track system coordinate frames
 	described by galvoScannerOrigin with a single value of type CartesianCoordinate,
 	described by galvoScannerType with a single value of type string.
 
-//Camera (note "Optical system by which objects are imaged and recorded.") is a type of SpecificSubsystem,
-Camera (note "Optical system by which objects are imaged and recorded.") is a type of System,
+Camera is a Sensor,
+	described by systemSpecification with a single value of type CameraSpecification.
+
+CameraSpecification is a type of SensorSpecification,
 	described by cameraImageWidth (note "Camera image width in pixel.") with a single value of type Measurement,
 	described by cameraBitDepth (note "Bit depth of pixel values.") with a single value of type Measurement,
-	described by cameraLastCameraCalibration (note "Date of the last camera calibration.") with a single value of type dateTime,
-	described by cameraModel (note "Model name of the camera defined by the manufacturer.") with a single value of type string,
-	described by cameraManufacturer (note "Manufacture name of the camera.") with a single value of type Organization,
 	described by cameraImageHeight (note "Camera image height in pixel.") with a single value of type Measurement,
+	// What does cameraCenter mean?
 	described by cameraCenter (note "Width, Height center position of a camera in pixels.") with a single value of type CartesianCoordinate,
 	described by cameraOpticalFilterBandwidth (note "Bandwidth of a camera's filter bandwidth.") with a single value of type Measurement,
 	described by cameraDetectorPitchSize (note "Camera detection pitch size.") with a single value of type Measurement,
 	described by cameraDigitalMagnification (note "Magnification factor setting of a camera.") with a single value of type Measurement,
 	described by cameraLensOpticalMagnification with a single value of type float,
 	described by cameraMinShutterSpeed (note "Shutter speed of a camera.") with a single value of type Measurement,
-	described by cameraFrameRate (note "Framerate of a camera setting.") with a single value of type Measurement
-	described by cameraLensAperture with a single value of type Measurement,
-	described by cameraLensManufacturer with a single value of type string,
-	described by cameraLensFilter with a single value of type string.
 
-//Photodiode is a type of SpecificSubsystem,
-Photodiode is a type of System,
-	described by photodiodeModel with a single value of type string,
-	described by photodiodeManufacturer with a single value of type Organization,
+Lens is a Sensor,
+	described by systemSpecification with a single value of type LensSpecification.
+
+LensSpecification is a type of SensorSpecification,
+	described by lensAperture with a single value of type Measurement,
+	described by lensFilter with a single value of type string.
+
+photoDiode is a Sensor,
+	described by systemSpecification with a single value of type photoDiodeSpecification.
+
+photoDiodeSpecification is a type of SensorSpecification,
 	described by photodiodeOpticalFilterBandwidth with a single value of type Measurement,
 	described by photodiodeBitDepth with a single value of type Measurement,
-	described by photodiodeSamplingRate with a single value of type Measurement,
-	described by photodiodeLastPhotodiodeCalibration with a single value of type dateTime.
 
-//Pyrometer is a type of SpecificSubsystem,
-Pyrometer is a type of System,
-	described by pyrometerModel with a single value of type string,
-	described by pyrometerManufacturer with a single value of type Organization,
+Pyrometer is a Sensor,
+	described by systemSpecification with a single value of type PyrometerSpecification.
+
+PyrometerSpecification is a type of SensorSpecification,
 	described by pyrometerOpticalFilterBandwidth1 with a single value of type Measurement,
 	described by pyrometerOpticalFilterBandwidth2 with a single value of type Measurement,
 	described by pyrometerBitDepth with a single value of type Measurement,
-	described by pyrometerSamplingRate with a single value of type Measurement,
-	described by pyrometerLastPyrometerCalibration with a single value of type dateTime.
 
-//AMSystem Types; used for refinement of attributes based on type
 LaserPowderBedFusionSystem is a type of AMSystem.
-//	described by laserPowderBedFusionSpecificAttribute with a single value of type string.
 
 ElectronBeamPowderBedFusionSystem is a type of AMSystem.
-//	described by electronbeamPowderBedFusionSpecificAttribute with a single value of type string.
 
 DirectedEnergyDepositionSystem is a type of AMSystem.
-//	described by directedEnergyDepositionSpecificAttribute with a single value of type string.
 
 BinderJetSystem is a type of AMSystem.
-//	described by binderJetSpecificAttribute with a single value of type string.
 
-// Detailed Characteristics
 BuildEnvironmentalControl (note "Environment control of the build chamber on its temperature, pressure, humidity and oxygen level, for optimal quality of AM material transformation.") is a class,
 	described by buildEnvironmentControlShieldingGasType with a single value of type string,
 	described by buildEnvironmentControlMaximumPreheatingTemperature with a single value of type Measurement,
@@ -181,9 +145,31 @@ MachineCapability (note "Vendor-provided AM machine specification.") is a class,
 	described by machineCapabilityMinimumOxygenLevel with a single value of type Measurement,
 	described by machineCapabilityMinimumMoistureLevel with a single value of type Measurement.
 
-MaintenanceEvent is a class,
-	described by maintenanceDate (note "Date of last AM system Maintenance.") with a single value of type dateTime,
-	described by maintenanceReport (note "Technical report from the maintenance.") with a single value of type Document.
+SystemQualificationEvent is a type of PlannedProcessStep,
+	described by processData (note "Process monitoring data, in-situ monitoring data, real-time monitoring etc, real-time control information.") with a single value of type SystemQualificationEventData.
+
+SystemQualificationEventData is a type of ProcessData,
+	described by systemQualDataPassFail (note "Pass / fail result.") with a single value of type string,
+	described by systemQualDataResults (note "A certification capturing the basic calibration and test build(s) performed after installation of machine; aka, suite acceptance report, tied to a machine serial number.") with a single value of type string.
+
+InstallationQualification is a type of SystemQualificationEvent.
+
+OperationalQualification is a type of SystemQualificationEvent.
+
+PerformanceQualification is a type of SystemQualificationEvent.
+
+MaintenanceEvent is a type of PlannedProcessStep,
+	described by processData (note "Process monitoring data, in-situ monitoring data, real-time monitoring etc, real-time control information.") with a single value of type MaintenanceEventData.
+
+MaintenanceEventData is a type of ProcessData,
+	described by maintenanceDataReport (note "Technical report from the maintenance.") with a single value of type Document.
+
+SystemCalibration (note "Calibration information.") is a type of MaintenanceEvent,
+	described by processData (note "Process monitoring data, in-situ monitoring data, real-time monitoring etc, real-time control information.") with a single value of type SystemCalibrationData.
+
+SystemCalibrationData is a type of ProcessData,
+	described by calibrationPassFail (note "Pass / fail result.") with a single value of type string,
+	described by calibrationDataResults (note "The results of the equipment calibration (files, etc.).") with a single value of type Document,
 
 Software is a class,
 	described by softwareName (note "A unique identifier for the software.") with a single value of type string,

--- a/SADL/AM-CDM-system.sadl
+++ b/SADL/AM-CDM-system.sadl
@@ -4,6 +4,7 @@ import "http://kdl.ge.com/AM-CDM-material".
 
 System (note "A manufacturing system that may be an aggregate of subsystems.") is a class,
 	described by systemID (note "Unique identifier of equipment.") with a single value of type string,
+	described by systemSerialNumber (note "The serial number of the equipment defined by the vendor.") with a single value of type string,
 	described by systemName (note "The name of the equipment.") with a single value of type string,
 	described by systemPurchaseDate (note "The purchase/certification date of the installed equipment.") with a single value of type dateTime,
 	described by systemOwner (note "The owner/organization of the equipment.") with a single value of type Organization,
@@ -16,7 +17,6 @@ System (note "A manufacturing system that may be an aggregate of subsystems.") i
 SystemSpecification is a class,
 	described by systemModel (note "Model name of a machine defined by the machine manufacturer.") with a single value of type string,
 	described by systemManufacturer (note "The manufacturer of the equipment.") with a single value of type Organization,
-	described by systemSerialNumber (note "The serial number of the equipment defined by the vendor.") with a single value of type string,
 	described by systemSpecElectricVoltage (note "Voltage for an AM Machine's electrical connection.") with a single value of type Measurement,
 	described by systemSpecPowerIntensity (note "Current intensity required to power an AM Machine.") with a single value of type Measurement,
 	described by systemSpecPowerFrequency (note "Power frequency for the electrical connection of an AM Machine.") with a single value of type Measurement,


### PR DESCRIPTION
I've quickly refactored system to align it with the rest of the data model as well as data modeling best practices:
1. I've separated the specification of a system from the system itself. This separates a specific serial number of an EOS M290 maintenance history from the more abstract concept of the voltage requirements for an EOS M290.
2. I've taken advantage of inheritance to remove redundant attributes
3. I've made it so that all systems have a process history
4. I've made it so that IQ/OQ/PC are all processes
5. I've taken advantage of inheritance in properties to eliminate more attributes

This was a quick refactor. I did not update the excel sheet of shorthands or correct the shorthands as I went.